### PR TITLE
Add brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Small tool to convert an IAM Policy in JSON format into a Terraform [`aws_iam_po
 
 ## Installation
 
-Download the latest binary from the [releases page](https://github.com/flosell/iam-policy-json-to-terraform/releases) and put it into your `PATH` under the name `iam-policy-json-to-terraform`
+### OSX
 
     brew install iam-policy-json-to-terraform
+    
+### Other
+
+Download the latest binary from the [releases page](https://github.com/flosell/iam-policy-json-to-terraform/releases) and put it into your `PATH` under the name `iam-policy-json-to-terraform`
+
+### Developer
 
 If you're a go developer and have your `GOPATH` defined and have added your `$GOPATH/bin` directory to your path, you can simply run this command.
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,31 @@ Small tool to convert an IAM Policy in JSON format into a Terraform [`aws_iam_po
 
 Download the latest binary from the [releases page](https://github.com/flosell/iam-policy-json-to-terraform/releases) and put it into your `PATH` under the name `iam-policy-json-to-terraform`
 
+    brew install iam-policy-json-to-terraform
+
 If you're a go developer and have your `GOPATH` defined and have added your `$GOPATH/bin` directory to your path, you can simply run this command.
 
     go get github.com/flosell/iam-policy-json-to-terraform
 
 ## Usage
 
+From raw JSON
+
+```bash
+$ echo '{"Statement":[{"Effect":"Allow","Action":["ec2:Describe*"],"Resource":"*"}]}' | iam-policy-json-to-terraform
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["ec2:Describe*"]
+  }
+}
 ```
+
+From a JSON policy file
+
+```bash
 $ iam-policy-json-to-terraform < some-policy.json
 ```
 


### PR DESCRIPTION
From https://github.com/flosell/iam-policy-json-to-terraform/issues/3

```
$ brew install iam-policy-json-to-terraform
Updating Homebrew...
==> Auto-updated Homebrew!
Updated Homebrew from 4d00a7bfe to e7130bfc2.
Updated 2 taps (homebrew/cask and homebrew/cask-fonts).

==> Downloading https://homebrew.bintray.com/bottles/iam-policy-json-to-terraform-1.3.0.catalina.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/ef/ef3fc3988992318aaba7c08cdf0673c926582a5702fefe41bde207d6b8ab0334?__gda__=exp=15820
######################################################################## 100.0%
==> Pouring iam-policy-json-to-terraform-1.3.0.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/iam-policy-json-to-terraform/1.3.0: 6 files, 2.8MB

$ iam-policy-json-to-terraform --version
1.3.0
```