### PR TITLE
Add syntax highlight for hcl block

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,14 @@
             flex-basis: 100%;
         }
 
+        .textContainer pre {
+            border-width: 1px;
+            border-style: solid;
+            border-color: rgb(118, 118, 118);
+            flex-basis: 100%;
+            white-space: pre-wrap;
+        }
+
         .buttonContainer {
             flex-basis: 10%;
             flex-flow: row nowrap;
@@ -39,6 +47,10 @@
             height: 10em;
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/themes/prism.min.css"
+        referrerpolicy="no-referrer"
+        crossorigin="anonymous"
+        integrity="sha512-tN7Ec6zAFaVSG3TpNAKtk4DOHNpSwKHxxrsiw4GHKESGPs5njn/0sMCUMl2svV4wo4BK/rCP7juYz+zx+l6oeQ==" />
 </head>
 <body>
 <div class="mainContainer">
@@ -54,12 +66,24 @@
     </div>
     <div class="textContainer">
         <label for="output">Output: Terraform</label>
-        <textarea id="output" readonly></textarea>
+        <pre id="output" class="language-hcl"></pre>
     </div>
 </div>
 <div>
     <a href="javascript:if(document.getSelection){s=document.getSelection();}else{s= '{}';};document.location='https://flosell.github.io/iam-policy-json-to-terraform/#content='+encodeURIComponent(s)">Bookmarklet</a> drag this into your bookmarks; select a valid IAM policy on any page and click the bookmark to convert in one click
 </div>
+<script type="application/javascript">
+    window.Prism = window.Prism || {};
+    Prism.manual = true;
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/components/prism-core.min.js"
+        referrerpolicy="no-referrer"
+        crossorigin="anonymous"
+        integrity="sha512-TbHaMJHEmRBDf9W3P7VcRGwEmVEJu7MO6roAE0C4yqoNHeIVo3otIX3zj1DOLtn7YCD+U8Oy1T9eMtG/M9lxRw=="></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/components/prism-hcl.min.js"
+        referrerpolicy="no-referrer"
+        crossorigin="anonymous"
+        integrity="sha512-swbu7APQjzOJzQrot5PC5xlX+6Q45sZZpjbnUeabv/mjhF35bcYOWnaIHN6N7cxZjSVM/8kH2Vg+4vBsOnNxKw=="></script>
 <script src="web.js"></script>
 <script type="application/javascript">
     let inputTextBox = document.getElementById("input")
@@ -71,7 +95,9 @@
         } catch (e) {
             output = "Could not convert:\n" + e.message
         }
-        outputTextBox.value = output
+
+        outputTextBox.textContent = output
+        Prism.highlightElement(outputTextBox)
     }
     document.getElementById("doConvert").addEventListener("click", convertToHcl)
 

--- a/web/web_test.js
+++ b/web/web_test.js
@@ -42,13 +42,13 @@ class Page {
 let p = new Page()
 
 test('happy path', async t => {
-    await t.expect(p.output.value)
+    await t.expect(p.output.textContent)
         .eql('data "aws_iam_policy_document" "hello" {}\n')
 
     await p.replaceInputText(someIamJson)
     await t.click(p.convertButton)
 
-    await t.expect(p.output.value)
+    await t.expect(p.output.textContent)
         .eql(someIamTerraform)
 });
 
@@ -56,11 +56,11 @@ test('error case', async t => {
     await p.replaceInputText('{')
     await t.click(p.convertButton)
 
-    await t.expect(p.output.value)
+    await t.expect(p.output.textContent)
         .contains('unexpected end of JSON input')
 });
 
 test.page`./index.html#content=${encodeURIComponent(someIamJson)}`('bookmarklets', async t => {
     await t
-        .expect(p.output.value).eql(someIamTerraform);
+        .expect(p.output.textContent).eql(someIamTerraform);
 });


### PR DESCRIPTION
Thank you for creating this tool, it's very useful!

This PR adds syntax highlight for terraform part using [Prism.js](https://prismjs.com/). Prism seems like a good option since it has native HCL support and support for [live syntax highlights](https://live.prismjs.com/) which can be used later to add JSON syntax.

<img width="1436" alt="Screenshot 2021-10-21 at 00 57 10" src="https://user-images.githubusercontent.com/9439689/138188638-4fbdd35e-164c-4588-b6af-744b93111650.png">

Relates to #27 

Happy Hacktoberfest!