### PR TITLE
Don't output 'sid' if it's not set in the JSON

### DIFF
--- a/converter/encode.go
+++ b/converter/encode.go
@@ -14,7 +14,7 @@ type hclPrincipal struct {
 }
 
 type hclStatement struct {
-	Sid           string         `hcl:"sid"`
+	Sid           string         `hcl:"sid" hcle:"omitempty"`
 	Effect        string         `hcl:"effect"`
 	Resources     []string       `hcl:"resources"`
 	NotResources  []string       `hcl:"not_resources"`

--- a/converter/fixtures/simple.tf
+++ b/converter/fixtures/simple.tf
@@ -54,7 +54,6 @@ data "aws_iam_policy_document" "policy" {
   }
 
   statement {
-    sid    = ""
     effect = "Deny"
 
     not_resources = [
@@ -77,7 +76,6 @@ data "aws_iam_policy_document" "policy" {
   }
 
   statement {
-    sid     = ""
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
@@ -92,7 +90,6 @@ data "aws_iam_policy_document" "policy" {
   }
 
   statement {
-    sid     = ""
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 

--- a/converter/fixtures/single-statement.tf
+++ b/converter/fixtures/single-statement.tf
@@ -1,6 +1,5 @@
 data "aws_iam_policy_document" "policy" {
   statement {
-    sid       = ""
     effect    = "Deny"
     resources = ["*"]
     actions   = ["*"]

--- a/converter/fixtures/tf-interpolations.tf
+++ b/converter/fixtures/tf-interpolations.tf
@@ -44,7 +44,6 @@ data "aws_iam_policy_document" "policy" {
   }
 
   statement {
-    sid       = ""
     effect    = "Allow"
     resources = ["${aws_kms_key.key.arn}"]
 


### PR DESCRIPTION
First of all, thank you for an excellent tool!

The current version of `iam-policy-json-to-terraform` _always_ outputs `sid`, even if none in defined in the input policy. This is not a huge problem, but I think it could be nice to reduce the policy length (AWS has an upper limit for document size) and I think it increases readability.

## Current behavior

Input:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "iam:GetAccount*",
                "iam:ListAccount*"
            ],
            "Resource": "*"
        }
    ]
}
```

Output:

```hcl
data "aws_iam_policy_document" "policy" {
  statement {
    sid       = ""  # <-- empty sid (not present in the input)
    effect    = "Allow"
    resources = ["*"]

    actions = [
      "iam:GetAccount*",
      "iam:ListAccount*",
    ]
  }
}
```

## Suggested behavior

Input:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "iam:GetAccount*",
                "iam:ListAccount*"
            ],
            "Resource": "*"
        }
    ]
}
```

Output:

```hcl
data "aws_iam_policy_document" "policy" {
  statement {
    effect    = "Allow"
    resources = ["*"]

    actions = [
      "iam:GetAccount*",
      "iam:ListAccount*",
    ]
  }
}
```

`sid` no longer present in the output.

## Potential problem with the suggested change

The suggested change omits the `sid` if it's defined as an empty string in the input JSON:

Input:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Action": [
                "iam:GetAccount*",
                "iam:ListAccount*"
            ],
            "Resource": "*"
        }
    ]
}
```

Output:

```hcl
data "aws_iam_policy_document" "policy" {
  statement {
    effect    = "Allow"
    resources = ["*"]

    actions = [
      "iam:GetAccount*",
      "iam:ListAccount*",
    ]
  }
}
```

I don't think excluding the empty sid is a problem, but if it's an undesired default behavior I suggest adding a flag such `-omit-empty-sid`.