### PR TITLE
Fix flaky web CI: wait for local server before running web tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,9 +139,7 @@ jobs:
           ./go tools_web
       - name: Wait for version deployed
         run: ./go wait_for_deployed
-        # GitHub Pages CDN propagation is occasionally slower than 5 minutes,
-        # which caused flaky failures here. Give it more headroom.
-        timeout-minutes: 10
+        timeout-minutes: 5
       - name: Run E2E tests
         run: ./go web_e2e_deployed
   test-readme:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,9 @@ jobs:
           ./go tools_web
       - name: Wait for version deployed
         run: ./go wait_for_deployed
-        timeout-minutes: 5
+        # GitHub Pages CDN propagation is occasionally slower than 5 minutes,
+        # which caused flaky failures here. Give it more headroom.
+        timeout-minutes: 10
       - name: Run E2E tests
         run: ./go web_e2e_deployed
   test-readme:

--- a/go
+++ b/go
@@ -165,11 +165,30 @@ goal_test_readme() { ## Run the commands mentioned in the README for sanity-chec
   scripts/test-readme.sh
 }
 
+wait_for_server() {
+  local url="${1}"
+  local timeout_seconds="${2:-60}"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  echo "Waiting for server at ${url} to accept connections..."
+  until curl -sSf -o /dev/null "${url}"; do
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+      die "Server at ${url} did not become ready within ${timeout_seconds}s"
+    fi
+    sleep 0.5
+  done
+  echo "Server at ${url} is ready"
+}
+
 web_serve_background() {
   cd web
   npx serve -l 8080 &
   background_pids+=("$!")
   cd ..
+  # Wait until the server actually accepts connections before returning.
+  # Otherwise callers (e2e / visual regression) start hitting the server
+  # before it is listening, causing flaky navigation timeouts.
+  wait_for_server "http://localhost:8080/" 60
 }
 
 goal_web_serve() { ## Serve the web version on a local development server


### PR DESCRIPTION
## Investigation

I reviewed recent GitHub Actions runs of the `main pipeline` workflow. Ignoring deterministic failures (e.g. `requires go version 1.19 through 1.24, got go1.25` — a tinygo/Go incompatibility that was fixed by a version bump), two genuinely *flaky* patterns stood out, and several runs only went green on attempt 2 or 3:

### 1. `web-test` job — visual regression navigation timeout (primary)
Failing runs (e.g. [29153907740](https://github.com/flosell/iam-policy-json-to-terraform/actions/runs/29153907740), [28121713388](https://github.com/flosell/iam-policy-json-to-terraform/actions/runs/28121713388)) died in backstop with:

```
Puppeteer encountered an error while running scenario "Normal"
TimeoutError: Navigation timeout of 60000 ms exceeded
...
Error: Mismatch errors found.
```

(The accompanying "Reference image not found" lines are a *symptom* — the reference bitmaps exist in the repo; the timeout just meant no test bitmap was captured to compare.)

**Root cause:** `web_serve_background` in `./go` launched `npx serve` in the background and returned **immediately**, without waiting for the server to accept connections. Both `web_e2e` and `web_visual_regression_test` then started hitting the server before it was listening. The e2e test file already carried a hand-added `t.wait(1000)` workaround with a comment noting "on the pipeline this test is flaky" — same underlying race.

**Reproduced locally:** launching `npx serve -l 8080` exactly as the script does and immediately requesting the server returns no connection (`HTTP 000`); it only becomes ready ~1.4s later — and that window grows under CI load.

### 2. `web-test-after-deployment` job — deploy wait timeout
Failing runs (e.g. [28708844941](https://github.com/flosell/iam-policy-json-to-terraform/actions/runs/28708844941), [28706277868](https://github.com/flosell/iam-policy-json-to-terraform/actions/runs/28706277868)) hit `The action 'Wait for version deployed' has timed out after 5 minutes` — the newly deployed version simply hadn't propagated through the GitHub Pages CDN yet. External latency, not a code bug.

## Changes

- **`go`**: add a `wait_for_server` helper that polls the URL until it accepts connections (60s cap, fails loudly otherwise) and call it from `web_serve_background`. This closes the race for **every** consumer of the helper (e2e and visual regression), rather than papering over it per-test.
- **`.github/workflows/main.yml`**: raise the `Wait for version deployed` step timeout from 5 → 10 minutes to absorb occasional slow Pages CDN propagation.

## Verification

- Reproduced the readiness race with the real `npx serve` command (server not ready immediately after launch).
- Verified `wait_for_server` blocks until a slow-starting server is reachable and then returns success.
- `bash -n go` passes.

## Notes / follow-ups (not in this PR)

- The `t.wait(1000)` workaround in `web/web_test.js` guards a *different* timing issue (app JS not loaded when `#info-toggle` is clicked), so I left it untouched.
- Failure mode #2 is inherently external; if it persists, options include polling the deployment API instead of the published `version.txt`, or treating a slow deploy as a soft failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KigwUPCBqZBV9DKU5X4Zhr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KigwUPCBqZBV9DKU5X4Zhr)_