### PR TITLE
Replace fixed sleep in web e2e test with deterministic readiness wait

### DIFF
--- a/web/web_test.js
+++ b/web/web_test.js
@@ -109,10 +109,12 @@ test('update to error case', async t => {
 });
 
 test('collapse infos', async t => {
-    // somehow, on the pipeline this test is flaky;
-    // assuming this is because the code behind the info-toggle hasn't loaded yet by the time it's clicked
-    // so waiting a bit and see if that fixes the problem
-    await t.wait(1000)
+    // The #info-toggle click handler is only wired up once the WASM module has
+    // loaded and initialize() has run. initialize() populates #output with the
+    // converted document immediately before attaching that handler, so waiting
+    // for the output to appear deterministically guarantees the handler is bound
+    // before we click - more reliable than a fixed sleep.
+    await t.expect(p.output.textContent).contains('data "aws_iam_policy_document" "hello"')
     await t.expect(p.infoExpander.visible).ok()
 
     await t


### PR DESCRIPTION
Follow-up to #196. That PR fixed the server-readiness race but deliberately left the other flakiness workaround in place; this removes it properly, as discussed there.

## Problem

The `collapse infos` test in `web/web_test.js` worked around flakiness with a fixed sleep:

```js
// somehow, on the pipeline this test is flaky;
// assuming this is because the code behind the info-toggle hasn't loaded yet by the time it's clicked
await t.wait(1000)
```

That assumption is correct. In `app.js`, the `#info-toggle` click handler is only attached inside `initialize()`, which runs **after** the WASM module finishes loading:

```js
WebAssembly.instantiateStreaming(...).then(function (obj) {
    go.run(wasm);
    initialize()   // attaches the #info-toggle click handler
})
```

So clicking too early is a no-op and the `notOk()` assertion fails. A fixed 1s sleep is both wasteful (always waits the full second) and still racy — under CI load, WASM init can take longer than 1s.

## Fix

`initialize()` populates `#output` with the converted document on the line **immediately before** it attaches the info-toggle handler (both synchronous, same tick):

```js
convertToHcl()                                  // fills #output with pre.language-hcl
infoToggleButton.addEventListener("click", ...) // <-- handler bound right after
```

So waiting for that output to appear is a deterministic proxy for "the handler is bound." The test now waits on it instead of sleeping:

```js
await t.expect(p.output.textContent).contains('data "aws_iam_policy_document" "hello"')
await t.expect(p.infoExpander.visible).ok()
```

TestCafe auto-retries the assertion until its timeout, so this waits exactly as long as needed and no longer. `#output` is empty in the static HTML (`<div id="output" class="hcl-editor"></div>`), so the wait can't resolve before WASM populates it.

## Verification

- Confirmed via `app.js` that the `#info-toggle` handler is attached in `initialize()` right after `convertToHcl()` populates `#output`.
- Confirmed `#output` is empty in `index.html`, so the readiness assertion cannot pass prematurely.
- `node --check web/web_test.js` passes.

I did not run the full web e2e suite locally (it needs the tinygo/binaryen WASM build plus headless Chrome); this is a test-only change and CI exercises it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KigwUPCBqZBV9DKU5X4Zhr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KigwUPCBqZBV9DKU5X4Zhr)_