### PR TITLE
Fix flaky converter tests: sort condition/principal map keys

### DIFF
--- a/converter/convert.go
+++ b/converter/convert.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"regexp"
+	"sort"
 	"strconv"
 )
 
@@ -18,16 +19,26 @@ func escapePolicyVariables(s string) string {
 
 func convertConditions(conditions map[string]map[string]stringOrStringArray) []hclCondition {
 	result := make([]hclCondition, 0)
-	for k, v := range conditions {
-		for k2, v2 := range v {
+	for _, k := range sortedKeys(conditions) {
+		v := conditions[k]
+		for _, k2 := range sortedKeys(v) {
 			result = append(result, hclCondition{
 				Test:     k,
 				Variable: k2,
-				Values:   convertStringOrStringArray(v2),
+				Values:   convertStringOrStringArray(v[k2]),
 			})
 		}
 	}
 	return result
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func convertPrincipals(v stringOrMapWithStringOrStringArray) []hclPrincipal {
@@ -40,12 +51,13 @@ func convertPrincipals(v stringOrMapWithStringOrStringArray) []hclPrincipal {
 			},
 		}
 	case map[string]interface{}:
-		result := make([]hclPrincipal, 0)
 		// revive:disable:unchecked-type-assertion
-		for k, v := range v.(map[string]interface{}) {
+		m := v.(map[string]interface{})
+		result := make([]hclPrincipal, 0)
+		for _, k := range sortedKeys(m) {
 			result = append(result, hclPrincipal{
 				Type:        k,
-				Identifiers: convertStringOrStringArray(v),
+				Identifiers: convertStringOrStringArray(m[k]),
 			})
 		}
 		return result


### PR DESCRIPTION
## Summary

`TestConvertFromJsonToTerraformHcl/fixtures/single-statement.json` was flaky (e.g. [this run](https://github.com/flosell/iam-policy-json-to-terraform/actions/runs/29688591357/job/88197187626)), intermittently failing with the two `condition` blocks in a swapped order.

Root cause: `convertConditions` and `convertPrincipals` in `converter/convert.go` iterate over Go maps (`map[string]map[string]stringOrStringArray` and `map[string]interface{}`) without sorting the keys first. Go map iteration order is randomized, so the generated HCL statement's condition/principal blocks came out in a random order each run — matching the expected fixture output only by chance.

## Fix

- Added a small `sortedKeys[V any](m map[string]V) []string` helper.
- `convertConditions` now iterates conditions and their nested test/variable maps in sorted key order.
- `convertPrincipals` now iterates the principal type map in sorted key order.

This makes the generated HCL output deterministic for a given input.

## Test plan

- [x] `go test ./converter/... -count=1` run 30 times in a loop with no failures (previously failed intermittently).
- [x] `go build ./converter/...` and `go vet ./converter/...` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_015W8fiL9CMy56LhTTAMjFs9)_